### PR TITLE
Bugfix: Segfault when running `tf --num 0`.

### DIFF
--- a/src/bin/tf.rs
+++ b/src/bin/tf.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use anyhow::Error;
+use anyhow::{anyhow, Error};
 use regex::Regex;
 use structopt::StructOpt;
 
@@ -8,6 +8,12 @@ use topfew::{top_few_from_stream, KeyFinder};
 
 fn main() -> Result<(), Error> {
     let options = Options::from_args();
+    if options.num < 1 {
+        return Err(anyhow!(
+            "--num needs to be 1 or larger, got {}",
+            options.num
+        ));
+    }
     let sep = Regex::new(&options.regex)?;
     let kf = KeyFinder::new(Some(options.fields.indices), sep)?;
     let top_list = top_few_from_stream(options.file.into(), &kf, options.num)?;


### PR DESCRIPTION
The following line in counter.rs will trigger a crash:

```rust
let threshold = *top_values[self.num as usize - 1];
```

Solution: disallow `--num 0` as an input.